### PR TITLE
Add link to ECT to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ npm install js13k-packer
 
 ## Usage
 
-js13k-packer takes a single HTML input file and extracts all the CSS and JavaScript code, bundling them into single `<style>` and `<script>` elements in the HTML file. It then minifies the file, runs it through Roadroller, zips it, and finally runs ect on it.
+js13k-packer takes a single HTML input file and extracts all the CSS and JavaScript code, bundling them into single `<style>` and `<script>` elements in the HTML file. It then minifies the file, runs it through Roadroller, zips it, and finally runs [ect](https://github.com/fhanau/Efficient-Compression-Tool) on it.
 
 The result is a single zip file ready to upload.
 


### PR DESCRIPTION
Thanks for the great package!

I have a documentation suggestion. When I first read the README, I wasn't sure what `ect` was. Naively searching Google, npm, and GitHub didn't turn up anything. I think I've determined that `ect` is https://github.com/fhanau/Efficient-Compression-Tool. To make this clear to future users, I'd suggest adding a link to this page to the README.